### PR TITLE
Blog: man-page styled posts under /blog

### DIFF
--- a/docs/superpowers/plans/2026-05-31-man-page-blog.md
+++ b/docs/superpowers/plans/2026-05-31-man-page-blog.md
@@ -1,0 +1,378 @@
+# man-page Blog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a blog at `yankovs.com/blog` whose posts render like Unix man pages, matching the site's fullscreen-terminal aesthetic, with an RSS feed.
+
+**Architecture:** Astro 5 content collection (`blog`) of MDX files loaded via the glob loader. A `ManPage.astro` layout wraps post bodies in NAME/DESCRIPTION man structure and reuses the existing `Terminal.astro` shell. `/blog` lists posts man-apropos style; `/blog/[slug]` renders each post; `/rss.xml` emits a feed.
+
+**Tech Stack:** Astro 5, MDX (`@astrojs/mdx`, already installed), `@astrojs/rss`, Tailwind 4, TypeScript.
+
+**Testing note:** This project has no unit-test runner, and adding one for a static personal blog is out of scope (YAGNI). Each task's gate is `npm run build` (astro check + build) plus a stated manual verification. `npm run build` runs `astro check && astro build` per package.json.
+
+---
+
+### Task 1: Content collection + schema
+
+**Files:**
+- Create: `src/content.config.ts`
+
+- [ ] **Step 1: Create the collection config**
+
+```ts
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.mdx", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    section: z.number().default(1),
+    summary: z.string(),
+    date: z.coerce.date(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };
+```
+
+- [ ] **Step 2: Commit** (build verification happens in Task 2 once a post exists)
+
+```bash
+git add src/content.config.ts
+git commit -m "feat: blog content collection schema"
+```
+
+---
+
+### Task 2: Seed inaugural post
+
+**Files:**
+- Create: `src/content/blog/building-a-terminal-blog.mdx`
+
+- [ ] **Step 1: Write the post**
+
+```mdx
+---
+title: building-a-terminal-blog
+section: 1
+summary: building a blog that reads like a man page
+date: 2026-05-31
+---
+
+## Synopsis
+
+`cat ~/blog/building-a-terminal-blog.mdx`
+
+## Description
+
+This blog renders like a Unix man page. Posts are MDX files; the layout wraps
+them in the familiar NAME / DESCRIPTION structure, caps the section headings, and
+footers each page with `YANKOVS(1)` and the date.
+
+Write a post by dropping an `.mdx` file in `src/content/blog`. The `##` headings
+become man-style section headers automatically.
+
+## See also
+
+`ls ~/blog`, `/rss.xml`
+```
+
+- [ ] **Step 2: Build to verify the collection + post parse**
+
+Run: `npm run build`
+Expected: PASS — astro check reports 0 errors; build completes. (No `/blog` route yet; that's Task 4.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/blog/building-a-terminal-blog.mdx
+git commit -m "feat: inaugural blog post"
+```
+
+---
+
+### Task 3: ManPage layout
+
+**Files:**
+- Create: `src/layouts/ManPage.astro`
+
+Reuses `Terminal.astro` (StatusBar, Nav, theme, fonts). Renders the man structure around the post body passed as a slot. Caps-section styling for `##` headings is scoped to `.manpage`.
+
+- [ ] **Step 1: Write the layout**
+
+```astro
+---
+import Terminal from "./Terminal.astro";
+interface Props {
+  title: string;
+  section: number;
+  summary: string;
+  date: string;
+}
+const { title, section, summary, date } = Astro.props;
+---
+<Terminal title={`${title}(${section}) — yankovs.com`} route="/blog" description={summary}>
+  <article class="manpage">
+    <p class="section-head">NAME</p>
+    <p class="indent">{title} – {summary}</p>
+
+    <p class="section-head mt-6">DESCRIPTION</p>
+    <div class="indent">
+      <slot />
+    </div>
+
+    <footer class="manpage-footer dim mt-12">
+      <span>YANKOVS({section})</span>
+      <span>{date}</span>
+    </footer>
+  </article>
+</Terminal>
+
+<style is:global>
+  .manpage .section-head {
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .manpage .indent { margin-left: 2rem; }
+  /* MDX `##` headings render as man-style section headers */
+  .manpage h2 {
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    font-size: 1rem;
+    margin: 1.5rem 0 0.5rem;
+  }
+  .manpage h2 + * { margin-left: 0; }
+  .manpage-footer {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--border);
+    padding-top: 0.5rem;
+    font-size: 13px;
+  }
+</style>
+```
+
+- [ ] **Step 2: Commit** (rendered + verified via the post route in Task 5)
+
+```bash
+git add src/layouts/ManPage.astro
+git commit -m "feat: man-page layout"
+```
+
+---
+
+### Task 4: Blog index page
+
+**Files:**
+- Create: `src/pages/blog/index.astro`
+
+- [ ] **Step 1: Write the index**
+
+```astro
+---
+import Terminal from "../../layouts/Terminal.astro";
+import { getCollection } from "astro:content";
+
+const posts = (await getCollection("blog", ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const fmt = (d: Date) => d.toISOString().slice(0, 10);
+---
+<Terminal title="Martin Yankov — blog" route="/blog" description="Notes, rendered like man pages.">
+  <p class="dim">$ ls ~/blog</p>
+  <ul class="mt-4 list-none">
+    {posts.map((p) => (
+      <li class="blog-entry">
+        <a href={`/blog/${p.id}`}>{p.data.title}({p.data.section})</a>
+        <span class="ml-2">{p.data.summary}</span>
+        <span class="dim ml-2">{fmt(p.data.date)}</span>
+      </li>
+    ))}
+  </ul>
+  <p class="dim mt-8">$ <a href="/rss.xml">cat rss.xml</a></p>
+</Terminal>
+```
+
+- [ ] **Step 2: Build and serve, verify the index**
+
+Run: `npm run build && npm run preview`
+Expected: PASS. Visit `/blog` — shows `$ ls ~/blog`, the inaugural post entry `building-a-terminal-blog(1)` with summary + date, and the rss link. Stop preview (Ctrl-C).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/blog/index.astro
+git commit -m "feat: blog index (ls ~/blog)"
+```
+
+---
+
+### Task 5: Blog post route
+
+**Files:**
+- Create: `src/pages/blog/[slug].astro`
+
+- [ ] **Step 1: Write the dynamic route**
+
+```astro
+---
+import ManPage from "../../layouts/ManPage.astro";
+import { getCollection, render } from "astro:content";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const date = post.data.date.toISOString().slice(0, 10);
+---
+<ManPage
+  title={post.data.title}
+  section={post.data.section}
+  summary={post.data.summary}
+  date={date}
+>
+  <Content />
+</ManPage>
+```
+
+- [ ] **Step 2: Build and serve, verify the post**
+
+Run: `npm run build && npm run preview`
+Expected: PASS. Visit `/blog/building-a-terminal-blog` — renders NAME/DESCRIPTION, the `##` headings appear as caps section headers, footer shows `YANKOVS(1)` left and the date right. Theme toggle + nav present. Stop preview.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "src/pages/blog/[slug].astro"
+git commit -m "feat: blog post route with man-page rendering"
+```
+
+---
+
+### Task 6: RSS feed
+
+**Files:**
+- Modify: `package.json` (add dependency)
+- Create: `src/pages/rss.xml.ts`
+
+- [ ] **Step 1: Install @astrojs/rss**
+
+Run: `npm install @astrojs/rss`
+Expected: adds `@astrojs/rss` to dependencies, no errors.
+
+- [ ] **Step 2: Write the feed endpoint**
+
+```ts
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import type { APIContext } from "astro";
+
+export async function GET(context: APIContext) {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return rss({
+    title: "Martin Yankov",
+    description: "Notes, rendered like man pages.",
+    site: context.site!,
+    items: posts
+      .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+      .map((p) => ({
+        title: p.data.title,
+        description: p.data.summary,
+        pubDate: p.data.date,
+        link: `/blog/${p.id}/`,
+      })),
+  });
+}
+```
+
+- [ ] **Step 3: Build and verify the feed**
+
+Run: `npm run build && npm run preview`
+Expected: PASS. Visit `/rss.xml` — valid XML with one `<item>` for the inaugural post (title, description, pubDate, link). Stop preview.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json src/pages/rss.xml.ts
+git commit -m "feat: rss feed"
+```
+
+---
+
+### Task 7: Wire blog into Nav + RSS head link
+
+**Files:**
+- Modify: `src/components/Nav.astro`
+- Modify: `src/layouts/Terminal.astro`
+
+- [ ] **Step 1: Repoint the Nav blog item to internal /blog and add rss**
+
+In `src/components/Nav.astro`, replace the external blog item:
+
+```ts
+  { cmd: "open blog.yankovs.com", href: "https://blog.yankovs.com", external: true },
+```
+
+with:
+
+```ts
+  { cmd: "cd blog", href: "/blog" },
+  { cmd: "cat rss.xml", href: "/rss.xml" },
+```
+
+- [ ] **Step 2: Add the RSS alternate link to the document head**
+
+In `src/layouts/Terminal.astro`, after the favicon `<link>` (line 21), add:
+
+```astro
+    <link rel="alternate" type="application/rss+xml" title="Martin Yankov" href="/rss.xml" />
+```
+
+- [ ] **Step 3: Build and verify nav + head**
+
+Run: `npm run build && npm run preview`
+Expected: PASS. On any page the nav shows `$ cd blog` (→ /blog) and `$ cat rss.xml`; the old external blog.yankovs.com link is gone. Page source `<head>` contains the rss alternate link. Stop preview.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Nav.astro src/layouts/Terminal.astro
+git commit -m "feat: nav links to internal blog + rss alternate link"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Full clean build + check**
+
+Run: `npm run build`
+Expected: astro check 0 errors, build completes, output includes `blog/index.html`, `blog/building-a-terminal-blog/index.html`, `rss.xml`.
+
+- [ ] **Step 2: Draft-exclusion sanity check**
+
+Temporarily add `draft: true` to the inaugural post frontmatter, run `npm run build`, confirm the post is absent from `dist/blog/` and from `dist/rss.xml`. Revert the change.
+
+- [ ] **Step 3: Confirm no leftover blog.yankovs.com references in the app**
+
+Run: `grep -rn "blog.yankovs.com" src/`
+Expected: no matches.
+
+---
+
+## Post-merge follow-ups (not part of this PR's code)
+
+- Configure the 301 redirect `blog.yankovs.com` → `yankovs.com/blog` in the Netlify/DNS console.
+- Repoint the README's `blog.yankovs.com` link to `https://yankovs.com/blog`.
+- Merge order: land PR #2 (terminal site) first, then this blog PR.

--- a/docs/superpowers/specs/2026-05-31-man-page-blog-design.md
+++ b/docs/superpowers/specs/2026-05-31-man-page-blog-design.md
@@ -1,0 +1,104 @@
+# man-page blog under yankovs.com — design
+
+Date: 2026-05-31
+Status: approved
+
+## Goal
+
+Host the blog directly under `yankovs.com/blog`, sunset `blog.yankovs.com`, start
+fresh (no content migration). Posts read like Unix **man pages**, matching the
+site's fullscreen-terminal aesthetic.
+
+Ships as a **separate PR on top of PR #2** (the Astro terminal-site revamp).
+
+## Content model
+
+Astro content collection `blog`, MDX files in `src/content/blog/*.mdx`.
+Zod-validated frontmatter:
+
+```ts
+{
+  title: string,        // command name, e.g. "building-a-terminal-blog"
+  section: number = 1,  // man section number; default 1 (general)
+  summary: string,      // one-liner — shown in NAME line and on the index
+  date: Date,
+  draft: boolean = false
+}
+```
+
+- Slug = filename. URL = `/blog/<slug>`.
+- `draft: true` excludes the post from the build output and from RSS.
+- `section` gives the `NAME(1)` convention for free and leaves room to grow into
+  topic grouping later. No tag system now (YAGNI).
+
+## Routing & pages
+
+- **`/blog`** — index. Renders `$ ls ~/blog`, then posts as man-style entries:
+
+  ```
+  building-a-terminal-blog(1)   building a blog that reads like a man page   2026-05-31
+  ```
+
+  Sorted by `date` descending. Drafts hidden. Title links to the post.
+
+- **`/blog/[slug]`** — `getStaticPaths` over the collection, body wrapped in the
+  man-page layout.
+
+## Man-page rendering (`ManPage.astro`)
+
+Classic man structure:
+
+```
+NAME
+     building-a-terminal-blog – building a blog that reads like a man page
+
+DESCRIPTION
+     <MDX body renders here>
+
+                                                          YANKOVS(1)  2026-05-31
+```
+
+- `NAME` / `DESCRIPTION` headers in caps, accent color, hanging indent for body
+  (mimics real man layout).
+- MDX `##` headings restyle to caps section headers (`SYNOPSIS`, `EXAMPLES`, …)
+  so authors write normal markdown and it reads man-ish.
+- Footer mimics the man footer: left `YANKOVS(section)`, right the date.
+- Reuses the existing `Terminal.astro` shell (StatusBar, Nav, theme toggle,
+  self-hosted JetBrains Mono) for visual continuity with the rest of the site.
+
+## RSS
+
+- `@astrojs/rss` generates `/rss.xml` from non-draft posts (title, summary, date,
+  link).
+- Add `<link rel="alternate" type="application/rss+xml">` to the document head.
+
+## Nav
+
+- Replace the external `open blog.yankovs.com` item with internal `cd blog` →
+  `/blog`.
+- Add a small `rss` link in the nav.
+
+## Sunsetting blog.yankovs.com (deploy step — not code in this PR)
+
+301 redirect `blog.yankovs.com` → `yankovs.com/blog`, configured in the
+Netlify/DNS console. Documented here as a manual cutover step; this build does
+not ship it.
+
+After this PR merges, repoint the README's `blog.yankovs.com` link to
+`https://yankovs.com/blog`.
+
+## Seed content
+
+One inaugural post `building-a-terminal-blog.mdx` explaining the man-page concept
+— doubles as a living example of the format and gives the index real content.
+
+## Testing
+
+- `astro build` green; `astro check` clean.
+- Manually verify: `/blog` index, a post page, `/rss.xml` validates, draft
+  exclusion works, theme toggle + nav continuity hold on blog routes.
+
+## Out of scope (YAGNI)
+
+Tags, search, reading time, prev/next nav, per-post OG images, comments,
+content migration from the old blog.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/mdx": "^4.0.0",
+        "@astrojs/rss": "^4.0.18",
         "@fontsource/jetbrains-mono": "^5.1.0",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^5.0.0",
@@ -154,6 +155,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1317,6 +1338,18 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
@@ -4137,6 +4170,44 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -6255,6 +6326,21 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -6986,6 +7072,18 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -7900,6 +7998,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/mdx": "^4.0.0",
+    "@astrojs/rss": "^4.0.18",
     "@fontsource/jetbrains-mono": "^5.1.0",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^5.0.0",

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -3,13 +3,14 @@ interface Props {
   current: string;
 }
 const { current } = Astro.props;
-const items = [
+const items: { cmd: string; href: string; external?: boolean }[] = [
   { cmd: "cd ~",        href: "/" },
   { cmd: "cd about",    href: "/about" },
   { cmd: "cd now",      href: "/now" },
   { cmd: "cd building", href: "/building" },
   { cmd: "cd contact",  href: "/contact" },
-  { cmd: "open blog.yankovs.com", href: "https://blog.yankovs.com", external: true },
+  { cmd: "cd blog", href: "/blog" },
+  { cmd: "cat rss.xml", href: "/rss.xml" },
 ];
 ---
 <nav class="px-4 py-6 mt-8">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,15 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.mdx", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    section: z.number().default(1),
+    summary: z.string(),
+    date: z.coerce.date(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/building-a-terminal-blog.mdx
+++ b/src/content/blog/building-a-terminal-blog.mdx
@@ -1,0 +1,23 @@
+---
+title: building-a-terminal-blog
+section: 1
+summary: building a blog that reads like a man page
+date: 2026-05-31
+---
+
+## Synopsis
+
+`cat ~/blog/building-a-terminal-blog.mdx`
+
+## Description
+
+This blog renders like a Unix man page. Posts are MDX files; the layout wraps
+them in the familiar NAME / DESCRIPTION structure, caps the section headings, and
+footers each page with `YANKOVS(1)` and the date.
+
+Write a post by dropping an `.mdx` file in `src/content/blog`. The `##` headings
+become man-style section headers automatically.
+
+## See also
+
+`ls ~/blog`, `/rss.xml`

--- a/src/layouts/ManPage.astro
+++ b/src/layouts/ManPage.astro
@@ -20,11 +20,12 @@ const { title, section, summary, date } = Astro.props;
 
     <footer class="manpage-footer dim mt-12">
       <span>YANKOVS({section})</span>
-      <span>{date}</span>
+      <time datetime={date}>{date}</time>
     </footer>
   </article>
 </Terminal>
 
+<!-- global: scoped styles can't reach slotted MDX content (the `##` headings) -->
 <style is:global>
   .manpage .section-head {
     color: var(--accent);

--- a/src/layouts/ManPage.astro
+++ b/src/layouts/ManPage.astro
@@ -1,0 +1,52 @@
+---
+import Terminal from "./Terminal.astro";
+interface Props {
+  title: string;
+  section: number;
+  summary: string;
+  date: string;
+}
+const { title, section, summary, date } = Astro.props;
+---
+<Terminal title={`${title}(${section}) — yankovs.com`} route="/blog" description={summary}>
+  <article class="manpage">
+    <p class="section-head">NAME</p>
+    <p class="indent">{title} – {summary}</p>
+
+    <p class="section-head mt-6">DESCRIPTION</p>
+    <div class="indent">
+      <slot />
+    </div>
+
+    <footer class="manpage-footer dim mt-12">
+      <span>YANKOVS({section})</span>
+      <span>{date}</span>
+    </footer>
+  </article>
+</Terminal>
+
+<style is:global>
+  .manpage .section-head {
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .manpage .indent { margin-left: 2rem; }
+  /* MDX `##` headings render as man-style section headers */
+  .manpage h2 {
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    font-size: 1rem;
+    margin: 1.5rem 0 0.5rem;
+  }
+  .manpage h2 + * { margin-left: 0; }
+  .manpage-footer {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--border);
+    padding-top: 0.5rem;
+    font-size: 13px;
+  }
+</style>

--- a/src/layouts/Terminal.astro
+++ b/src/layouts/Terminal.astro
@@ -19,6 +19,7 @@ const { title, route, description, updated } = Astro.props;
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="alternate" type="application/rss+xml" title="Martin Yankov" href="/rss.xml" />
     <script is:inline>
       (() => {
         const stored = localStorage.getItem("theme");

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,24 @@
+---
+import ManPage from "../../layouts/ManPage.astro";
+import { getCollection, render } from "astro:content";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const date = post.data.date.toISOString().slice(0, 10);
+---
+<ManPage
+  title={post.data.title}
+  section={post.data.section}
+  summary={post.data.summary}
+  date={date}
+>
+  <Content />
+</ManPage>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -11,8 +11,8 @@ const fmt = (d: Date) => d.toISOString().slice(0, 10);
   <p class="dim">$ ls ~/blog</p>
   <ul class="mt-4 list-none">
     {posts.map((p) => (
-      <li class="blog-entry">
-        <a href={`/blog/${p.id}`}>{p.data.title}({p.data.section})</a>
+      <li>
+        <a href={`/blog/${p.id}/`}>{p.data.title}({p.data.section})</a>
         <span class="ml-2">{p.data.summary}</span>
         <span class="dim ml-2">{fmt(p.data.date)}</span>
       </li>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,22 @@
+---
+import Terminal from "../../layouts/Terminal.astro";
+import { getCollection } from "astro:content";
+
+const posts = (await getCollection("blog", ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const fmt = (d: Date) => d.toISOString().slice(0, 10);
+---
+<Terminal title="Martin Yankov — blog" route="/blog" description="Notes, rendered like man pages.">
+  <p class="dim">$ ls ~/blog</p>
+  <ul class="mt-4 list-none">
+    {posts.map((p) => (
+      <li class="blog-entry">
+        <a href={`/blog/${p.id}`}>{p.data.title}({p.data.section})</a>
+        <span class="ml-2">{p.data.summary}</span>
+        <span class="dim ml-2">{fmt(p.data.date)}</span>
+      </li>
+    ))}
+  </ul>
+  <p class="dim mt-8">$ <a href="/rss.xml">cat rss.xml</a></p>
+</Terminal>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -6,5 +6,5 @@ import Terminal from "../layouts/Terminal.astro";
   <pre class="mt-4 whitespace-pre-wrap">email     <a href="mailto:martin@yankovs.com">martin@yankovs.com</a>
 github    <a href="https://github.com/Lutherwaves">github.com/Lutherwaves</a>
 linkedin  <a href="https://linkedin.com/in/mdyankov">linkedin.com/in/mdyankov</a>
-blog      <a href="https://blog.yankovs.com">blog.yankovs.com</a></pre>
+blog      <a href="/blog">yankovs.com/blog</a></pre>
 </Terminal>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,20 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import type { APIContext } from "astro";
+
+export async function GET(context: APIContext) {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return rss({
+    title: "Martin Yankov",
+    description: "Notes, rendered like man pages.",
+    site: context.site!,
+    items: posts
+      .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+      .map((p) => ({
+        title: p.data.title,
+        description: p.data.summary,
+        pubDate: p.data.date,
+        link: `/blog/${p.id}/`,
+      })),
+  });
+}


### PR DESCRIPTION
## Summary
- New blog at `/blog`, posts render like Unix **man pages** (NAME/DESCRIPTION, caps section headers, `YANKOVS(n)` footer) — matches the fullscreen-terminal aesthetic
- Astro content collection (`blog`) of MDX, glob loader, zod schema (title, section, summary, date, draft)
- `/blog` index reads `$ ls ~/blog`; `/blog/[slug]` renders via a `ManPage` layout that reuses `Terminal.astro`
- RSS feed at `/rss.xml` (`@astrojs/rss`) + `<link rel="alternate">` in head
- Nav rewired: external `blog.yankovs.com` → internal `cd blog` + `cat rss.xml`; leftover link in contact page repointed
- One inaugural post documenting the format

Reviewed via subagent-driven development (spec-compliance + code-quality) and a full-branch review — verdict: ready to merge.

Spec: `docs/superpowers/specs/2026-05-31-man-page-blog-design.md` · Plan: `docs/superpowers/plans/2026-05-31-man-page-blog.md`

(Supersedes #3, which auto-closed when its base `astro-revamp` merged + was deleted.)

## Post-merge follow-ups (not in this PR)
- [ ] 301 redirect `blog.yankovs.com` → `yankovs.com/blog` (Netlify/DNS console)
- [ ] Repoint README's `blog.yankovs.com` link to `https://yankovs.com/blog`

## Test Plan
- [x] `npm run build` green — astro check 0 errors, 7 pages + `rss.xml` emitted
- [x] Draft exclusion verified (draft post absent from `dist/` and feed)
- [x] No `blog.yankovs.com` references left in `src/`
- [ ] Verify man-page rendering + theme/nav continuity on the deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)