### PR TITLE
Blog: ship-fast-adapt-faster post + site-wide Umami analytics

### DIFF
--- a/src/content/blog/building-a-terminal-blog.mdx
+++ b/src/content/blog/building-a-terminal-blog.mdx
@@ -20,4 +20,4 @@ become man-style section headers automatically.
 
 ## See also
 
-`ls ~/blog`, `/rss.xml`
+[`ls ~/blog`](/blog), [`/rss.xml`](/rss.xml)

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -3,7 +3,7 @@ title: ship-fast-adapt-faster
 section: 1
 summary: velocity is a byproduct of good questions, not a substitute for them
 date: 2026-06-02
-draft: true
+draft: false
 ---
 
 ## Synopsis

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -18,7 +18,7 @@ One says *move fast and break things*. Ship daily, ship ugly, momentum is the
 only moat. The other says *measure twice, cut once*. Slow down, think, don't
 make a mess you have to clean up later.
 
-Both are half right, which is the most dangerous kind of right.
+Both are half right, the way a person can be half-smart. Not good either way.
 
 Ship fast with nothing else and you build the wrong thing at high speed. Be
 careful with nothing else and you die slowly while someone less careful learns
@@ -38,7 +38,8 @@ ship a mess.
 
 ## Ship fast
 
-The point of shipping is not the artifact. It's the feedback.
+The point of shipping fast is to give users the thing and get feedback fast. It's
+not a race to the finish line.
 
 Unshipped code is a theory. It's a thing you believe is true about the world that
 the world has not yet confirmed or denied. Every day it sits on your machine, you

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -23,17 +23,17 @@ Both are half right, which is the most dangerous kind of right.
 Ship fast with nothing else and you build the wrong thing at high speed. Be
 careful with nothing else and you die slowly while someone less careful learns
 faster than you. The two camps are arguing about the wrong axis. Speed isn't the
-opposite of rigor. The thing that makes speed safe is rigor — applied to the
+opposite of rigor. The thing that makes speed safe is rigor, applied to the
 right step.
 
-Here's the loop I actually run: **ship fast, adapt faster, question everything.**
+The loop I run: **ship fast, adapt faster, question everything.**
 
 Everyone says AI made them ship faster. Be honest: it's *net* faster, not *way*
-faster. The real shift isn't speed per feature — it's that a feature that used to
+faster. The real shift isn't speed per feature. It's that a feature that used to
 need a team of ten to spec, crowd-write, and review, you can now hold in your head
 and build alone. So the pile of things you *could* build exploded. And that's what
 killed "we'll fix it later." When MVP and MVP+1 land in the same PR, fully
-unit-tested, every time — "later" stops being a phase. It's just a lie you tell to
+unit-tested, every time, "later" stops being a phase. It's just a lie you tell to
 ship a mess.
 
 ## Ship fast
@@ -42,19 +42,19 @@ The point of shipping is not the artifact. It's the feedback.
 
 Unshipped code is a theory. It's a thing you believe is true about the world that
 the world has not yet confirmed or denied. Every day it sits on your machine, you
-pay interest on a guess. Shipping is how you turn the guess into a fact — good or
+pay interest on a guess. Shipping is how you turn the guess into a fact. Good or
 bad, but a fact you can act on.
 
-So ship before it's ready, because "ready" is a feeling and feelings lie. Ship
-the version that's embarrassing-but-true over the version that's polished-but-
-hypothetical. The embarrassing one teaches you something this week.
+So ship before it's ready, because "ready" is a feeling and feelings lie. Ship the
+embarrassing version that's true over the polished version that's hypothetical. The
+embarrassing one teaches you something this week.
 
 ## Adapt faster
 
 This is the verb everyone in the *move fast* camp forgets.
 
 Shipping fast is worthless if you won't change course faster. If you ship daily
-but defend every decision like it's load-bearing, you're not fast — you're just
+but defend every decision like it's load-bearing, you're not fast. You're just
 accumulating mistakes at a higher frequency.
 
 The most expensive bug is building the wrong thing perfectly. You don't fix that
@@ -63,18 +63,17 @@ moment the feedback says you bet wrong. Don't marry the build. The build is a
 hypothesis you're trying to kill, and the faster you kill the bad ones, the
 faster the good one survives.
 
-Everyone agrees the hard part now is knowing *what* to build. Here's the catch:
-the answer usually shows up after you build it, not before. So the moat isn't a
-great idea — it's the speed at which you can destroy your own. Killing your ideas
-faster than you make them used to look like overthinking. Now it looks like an
-edge.
+Everyone agrees the hard part now is knowing *what* to build. The catch: the
+answer usually shows up after you build it, not before. So the moat isn't a great
+idea. It's the speed at which you can destroy your own. Killing your ideas faster
+than you make them used to look like overthinking. Now it looks like an edge.
 
 ## Question everything
 
 Ship fast and adapt faster are the engine. Questioning is the steering.
 
 A few weeks ago my own site was lying to people. `www.yankovs.com` loaded with a
-clean padlock. `yankovs.com` — the bare domain — threw a browser security warning.
+clean padlock. `yankovs.com`, the bare domain, threw a browser security warning.
 Same site, two doors, one of them screaming *insecure*.
 
 The fast fix is obvious: the certificate is stale, click renew, move on. That fix
@@ -83,11 +82,11 @@ nothing.
 
 So before touching anything: *why* is only the apex broken? That one question did
 all the work. The apex was serving the wrong certificate because the certificate
-authority could never verify the domain — and it couldn't verify because the
-domain was quietly resolving to three different IPs, two of them stale parking
-records injected by a forwarding setting I'd turned on years ago and forgotten.
-The renew button was never the problem. The problem was three houses down the
-street, and the only way to see it was to refuse the obvious fix and ask why first.
+authority could never verify the domain. And it couldn't verify because the domain
+was quietly resolving to three different IPs, two of them stale parking records
+injected by a forwarding setting I'd turned on years ago and forgotten. The renew
+button was never the problem. The actual problem was somewhere else entirely, and
+the only way to see it was to refuse the obvious fix and ask why first.
 
 Shipping fast gets you to the bug. Adapting fast gets you off the bad approach.
 But *question everything* is the part that points you at the right wall before you
@@ -99,16 +98,16 @@ debugging session is the one solving a problem you don't actually have.
 The three aren't a sequence, they're a loop, and they run at different speeds on
 purpose. Ship at the speed of "good enough to learn." Adapt at the speed of the
 feedback. Question constantly, in the background, especially when something is
-working — *especially* then.
+working. *Especially* then.
 
-And none of it counts until someone else uses it. You can ship and adapt at
-light speed and still hit the one wall that won't move: a human needs time to
-live with the thing before their feedback means anything. The only shortcut is
-building it so their AI uses it too — then even validation speeds up.
+And none of it counts until someone else uses it. You can ship and adapt at light
+speed and still hit the one limit that won't move: a human needs time to live with
+the thing before their feedback means anything. The only shortcut is building it so
+their AI uses it too. Then even validation speeds up.
 
-Here's the joke at the end of it. If everyone moves at light speed, nothing is
-fast. It's all relative. We sped everything up and landed right back at normal —
-running flat out, standing still.
+The joke at the end of it: if everyone moves at light speed, nothing is fast. It's
+all relative. We sped everything up and landed right back at normal. Running flat
+out, standing still.
 
 ## See also
 

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -23,8 +23,8 @@ Both are half right, the way a person can be half-smart. Not good either way.
 Ship fast with nothing else and you build the wrong thing at high speed. Be
 careful with nothing else and you die slowly while someone less careful learns
 faster than you. The two camps are arguing about the wrong axis. Speed isn't the
-opposite of rigor. The thing that makes speed safe is rigor, applied to the
-right step.
+opposite of rigor. Rigor at speed is the point, and it only works when you know
+where you're going. You can drive 200mph, but you have to know the direction.
 
 The loop I run: **ship fast, adapt faster, question everything.**
 
@@ -54,9 +54,9 @@ embarrassing one teaches you something this week.
 
 This is the verb everyone in the *move fast* camp forgets.
 
-Shipping fast is worthless if you won't change course faster. If you ship daily
-but defend every decision like it's load-bearing, you're not fast. You're just
-accumulating mistakes at a higher frequency.
+Shipping fast is worthless if you won't change course faster. Defend every
+decision like it's load-bearing and you might end up good, but slow. The speed
+that counts is how fast you drop the calls that turned out wrong.
 
 The most expensive bug is building the wrong thing perfectly. You don't fix that
 bug with better code. You fix it by being willing to throw the code away the
@@ -96,8 +96,7 @@ debugging session is the one solving a problem you don't actually have.
 
 ## Exit status
 
-The three aren't a sequence, they're a loop, and they run at different speeds on
-purpose. Ship at the speed of "good enough to learn." Adapt at the speed of the
+Run all three at once, each at its own speed. Ship at the speed of "good enough to learn." Adapt at the speed of the
 feedback. Question constantly, in the background, especially when something is
 working. *Especially* then.
 

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -1,0 +1,109 @@
+---
+title: ship-fast-adapt-faster
+section: 1
+summary: velocity is a byproduct of good questions, not a substitute for them
+date: 2026-06-02
+draft: true
+---
+
+## Synopsis
+
+`while true; do ship; question; adapt; done`
+
+## Description
+
+There are two tribes and they hate each other.
+
+One says *move fast and break things*. Ship daily, ship ugly, momentum is the
+only moat. The other says *measure twice, cut once*. Slow down, think, don't
+make a mess you have to clean up later.
+
+Both are half right, which is the most dangerous kind of right.
+
+Ship fast with nothing else and you build the wrong thing at high speed. Be
+careful with nothing else and you die slowly while someone less careful learns
+faster than you. The two camps are arguing about the wrong axis. Speed isn't the
+opposite of rigor. The thing that makes speed safe is rigor — applied to the
+right step.
+
+Here's the loop I actually run: **ship fast, adapt faster, question everything.**
+
+{/* TODO(martin): open with a 2-3 sentence personal hook in your voice — a recent
+moment where you shipped something, it was wrong, and you were glad you'd shipped
+because that's how you found out. This is the line that earns the reader. Mine
+below is a placeholder; yours will be better. */}
+
+## Ship fast
+
+The point of shipping is not the artifact. It's the feedback.
+
+Unshipped code is a theory. It's a thing you believe is true about the world that
+the world has not yet confirmed or denied. Every day it sits on your machine, you
+pay interest on a guess. Shipping is how you turn the guess into a fact — good or
+bad, but a fact you can act on.
+
+So ship before it's ready, because "ready" is a feeling and feelings lie. Ship
+the version that's embarrassing-but-true over the version that's polished-but-
+hypothetical. The embarrassing one teaches you something this week.
+
+## Adapt faster
+
+This is the verb everyone in the *move fast* camp forgets.
+
+Shipping fast is worthless if you won't change course faster. If you ship daily
+but defend every decision like it's load-bearing, you're not fast — you're just
+accumulating mistakes at a higher frequency.
+
+The most expensive bug is building the wrong thing perfectly. You don't fix that
+bug with better code. You fix it by being willing to throw the code away the
+moment the feedback says you bet wrong. Don't marry the build. The build is a
+hypothesis you're trying to kill, and the faster you kill the bad ones, the
+faster the good one survives.
+
+{/* TODO(martin): if you want one sanitized Blox moment — a decision you reversed
+fast, no product details — drop it here. It's the most on-mission paragraph in the
+post and the hardest for me to write without knowing the product. Totally fine to
+cut and lean on the cert story below instead. */}
+
+## Question everything
+
+Ship fast and adapt faster are the engine. Questioning is the steering.
+
+A few weeks ago my own site was lying to people. `www.yankovs.com` loaded with a
+clean padlock. `yankovs.com` — the bare domain — threw a browser security warning.
+Same site, two doors, one of them screaming *insecure*.
+
+The fast fix is obvious: the certificate is stale, click renew, move on. That fix
+would have failed, and I'd have clicked renew again, and again, and learned
+nothing.
+
+So before touching anything: *why* is only the apex broken? That one question did
+all the work. The apex was serving the wrong certificate because the certificate
+authority could never verify the domain — and it couldn't verify because the
+domain was quietly resolving to three different IPs, two of them stale parking
+records injected by a forwarding setting I'd turned on years ago and forgotten.
+The renew button was never the problem. The problem was three houses down the
+street, and the only way to see it was to refuse the obvious fix and ask why first.
+
+Shipping fast gets you to the bug. Adapting fast gets you off the bad approach.
+But *question everything* is the part that points you at the right wall before you
+start banging your head on it. Small steps, lots of questions. The most expensive
+debugging session is the one solving a problem you don't actually have.
+
+## Exit status
+
+The three aren't a sequence, they're a loop, and they run at different speeds on
+purpose. Ship at the speed of "good enough to learn." Adapt at the speed of the
+feedback. Question constantly, in the background, especially when something is
+working — *especially* then.
+
+Move fast and break things, sure. Just question which things, and adapt before
+they break you.
+
+{/* TODO(martin): closing line. Make it land. One sentence, your voice. Optional:
+end on whether building something quietly right now is teaching you this in real
+time — without naming it. */}
+
+## See also
+
+`ls ~/blog`, `building-a-terminal-blog(1)`

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -28,10 +28,13 @@ right step.
 
 Here's the loop I actually run: **ship fast, adapt faster, question everything.**
 
-{/* TODO(martin): open with a 2-3 sentence personal hook in your voice — a recent
-moment where you shipped something, it was wrong, and you were glad you'd shipped
-because that's how you found out. This is the line that earns the reader. Mine
-below is a placeholder; yours will be better. */}
+Everyone says AI made them ship faster. Be honest: it's *net* faster, not *way*
+faster. The real shift isn't speed per feature — it's that a feature that used to
+need a team of ten to spec, crowd-write, and review, you can now hold in your head
+and build alone. So the pile of things you *could* build exploded. And that's what
+killed "we'll fix it later." When MVP and MVP+1 land in the same PR, fully
+unit-tested, every time — "later" stops being a phase. It's just a lie you tell to
+ship a mess.
 
 ## Ship fast
 

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -63,10 +63,11 @@ moment the feedback says you bet wrong. Don't marry the build. The build is a
 hypothesis you're trying to kill, and the faster you kill the bad ones, the
 faster the good one survives.
 
-{/* TODO(martin): if you want one sanitized Blox moment — a decision you reversed
-fast, no product details — drop it here. It's the most on-mission paragraph in the
-post and the hardest for me to write without knowing the product. Totally fine to
-cut and lean on the cert story below instead. */}
+Everyone agrees the hard part now is knowing *what* to build. Here's the catch:
+the answer usually shows up after you build it, not before. So the moat isn't a
+great idea — it's the speed at which you can destroy your own. Killing your ideas
+faster than you make them used to look like overthinking. Now it looks like an
+edge.
 
 ## Question everything
 
@@ -100,12 +101,14 @@ purpose. Ship at the speed of "good enough to learn." Adapt at the speed of the
 feedback. Question constantly, in the background, especially when something is
 working — *especially* then.
 
-Move fast and break things, sure. Just question which things, and adapt before
-they break you.
+And none of it counts until someone else uses it. You can ship and adapt at
+light speed and still hit the one wall that won't move: a human needs time to
+live with the thing before their feedback means anything. The only shortcut is
+building it so their AI uses it too — then even validation speeds up.
 
-{/* TODO(martin): closing line. Make it land. One sentence, your voice. Optional:
-end on whether building something quietly right now is teaching you this in real
-time — without naming it. */}
+Here's the joke at the end of it. If everyone moves at light speed, nothing is
+fast. It's all relative. We sped everything up and landed right back at normal —
+running flat out, standing still.
 
 ## See also
 

--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -112,4 +112,4 @@ out, standing still.
 
 ## See also
 
-`ls ~/blog`, `building-a-terminal-blog(1)`
+[`ls ~/blog`](/blog), [`building-a-terminal-blog(1)`](/blog/building-a-terminal-blog)

--- a/src/layouts/Terminal.astro
+++ b/src/layouts/Terminal.astro
@@ -20,7 +20,7 @@ const { title, route, description, updated } = Astro.props;
     {description && <meta name="description" content={description} />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate" type="application/rss+xml" title="Martin Yankov" href="/rss.xml" />
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="e2c2ed80-0396-46ec-9f2e-14e75a8c7f09"></script>
+    <script defer src="https://eu.umami.is/script.js" data-website-id="e2c2ed80-0396-46ec-9f2e-14e75a8c7f09"></script>
     <script is:inline>
       (() => {
         const stored = localStorage.getItem("theme");

--- a/src/layouts/Terminal.astro
+++ b/src/layouts/Terminal.astro
@@ -20,6 +20,7 @@ const { title, route, description, updated } = Astro.props;
     {description && <meta name="description" content={description} />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate" type="application/rss+xml" title="Martin Yankov" href="/rss.xml" />
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="e2c2ed80-0396-46ec-9f2e-14e75a8c7f09"></script>
     <script is:inline>
       (() => {
         const stored = localStorage.getItem("theme");


### PR DESCRIPTION
## What

Draft of a sharp-opinion blog post for the founders / indie-hacker audience, in the man-page format. Built from the /office-hours brief.

**Thesis:** ship fast, adapt faster, question everything — speed isn't the opposite of rigor; the thing that makes speed safe is rigor applied to the right step. Velocity is a byproduct of good questions, not a substitute.

**Structure:** SYNOPSIS → SHIP FAST → ADAPT FASTER → QUESTION EVERYTHING → EXIT STATUS → SEE ALSO. The apex-domain TLS cert saga (the `yankovs.com` "insecure" bug) is the spine story — stealth-safe, real, and a clean illustration of "question the obvious fix first."

**Stealth:** reveals nothing about Blox.

## Status

`draft: true`, so it does NOT build into a live page yet. To preview it rendered, flip `draft: false` locally and run `npm run dev` → `/blog/ship-fast-adapt-faster`.

## What I need from you (3 spots, marked `TODO(martin)` in the MDX)

1. **Opening hook** (top of DESCRIPTION) — 2-3 sentences in your voice: a recent moment where you shipped, it was wrong, and you were glad you shipped because that's how you found out. This is the line that earns the reader; mine is a placeholder.
2. **Optional sanitized Blox moment** (in ADAPT FASTER) — a decision you reversed fast, no product details. Most on-mission paragraph, hardest for me to write blind. Cut it if it risks the stealth.
3. **Closing line** (end of EXIT STATUS) — one sentence, your voice, make it land.

Everything else is drafted and builds clean. Once you fill the three spots and flip `draft: false`, it's ready to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)