### PR TITLE
Blog + about: cut engine/steering line, drop em dashes from /about

### DIFF
--- a/src/content/blog/ship-fast-adapt-faster.mdx
+++ b/src/content/blog/ship-fast-adapt-faster.mdx
@@ -71,8 +71,6 @@ than you make them used to look like overthinking. Now it looks like an edge.
 
 ## Question everything
 
-Ship fast and adapt faster are the engine. Questioning is the steering.
-
 A few weeks ago my own site was lying to people. `www.yankovs.com` loaded with a
 clean padlock. `yankovs.com`, the bare domain, threw a browser security warning.
 Same site, two doors, one of them screaming *insecure*.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,7 +3,7 @@ import Terminal from "../layouts/Terminal.astro";
 ---
 <Terminal title="Martin Yankov — about" route="/about" description="About Martin Yankov.">
   <p>Hi, I'm Martin.</p>
-  <p class="mt-4">I'm a builder. Software, mostly — but I'll build whatever needs building.</p>
-  <p class="mt-4">I try to make things that help more than they hurt to use. I work in small steps, ask a lot of questions, and care about the person on the other end — the most expensive bug is building the wrong thing perfectly.</p>
+  <p class="mt-4">I'm a builder. Software, mostly, but I'll build whatever needs building.</p>
+  <p class="mt-4">I try to make things that help more than they hurt to use. I work in small steps, ask a lot of questions, and care about the person on the other end. The most expensive bug is building the wrong thing perfectly.</p>
   <p class="mt-4">Trilingual: English, German, Bulgarian.</p>
 </Terminal>


### PR DESCRIPTION
Drops the one corny line in the post ("Ship fast and adapt faster are the engine. Questioning is the steering."). The QUESTION EVERYTHING section now opens straight on the cert story, which is the point. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)